### PR TITLE
Added priority attribute to seed config to allow collections to be seeded in a specific order

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports = function(sails){
 
 function getModelsByPriority(){
   return _.sortBy(_.keys(sails.models), function(model){
-    return sails.config.seeds[model] && sails.config.seeds[model].priority;
+    return model.priority
   });
 };
 
@@ -86,13 +86,15 @@ function patchAttributes(callback){
       var data = sails.config.seeds[model.identity];
       if(data){
         var extend = {};
-        if(_.some([data.overwrite, data.unique], _.isDefined)){
+        if(_.some([data.overwrite, data.unique, data.priority], _.isDefined)){
           extend.seedData = data.data ? data.data : [];
           extend.overwrite = data.overwrite;
           extend.unique    = data.unique;
+          extend.priority    = data.priority;
         } else {
           extend.seedData = data;
           extend.overwrite = false;
+          extend.priority = 0;
         }
 
         _.extend(model, extend);

--- a/index.js
+++ b/index.js
@@ -42,11 +42,18 @@ module.exports = function(sails){
   };
 };
 
+
+function getModelsByPriority(){
+  return _.sortBy(_.keys(sails.models), function(model){
+    return sails.config.seeds[model] && sails.config.seeds[model].priority;
+  });
+};
+
 function seeds(callback){
   if(sails.config.seeds.disable){
     callback()
   } else {
-    async.each(_.keys(sails.models), function(model, cb){
+    async.each(getModelsByPrioriy(), function(model, cb){
       if(sails.models[model].seed && sails.config.seeds[model] && !(sails.config.seeds[model].active === false)){
         sails.models[model].seed(cb);
       } else {

--- a/index.js
+++ b/index.js
@@ -44,8 +44,8 @@ module.exports = function(sails){
 
 
 function getModelsByPriority(){
-  return _.sortBy(_.keys(sails.models), function(model){
-    return model.priority
+  return _.sortBy(_.keys(sails.models), function(key){
+    return sails.models[key].priority;
   });
 };
 
@@ -53,7 +53,7 @@ function seeds(callback){
   if(sails.config.seeds.disable){
     callback()
   } else {
-    async.each(getModelsByPriority(), function(model, cb){
+    async.eachSeries(getModelsByPriority(), function(model, cb){
       if(sails.models[model].seed && sails.config.seeds[model] && !(sails.config.seeds[model].active === false)){
         sails.models[model].seed(cb);
       } else {

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ function seeds(callback){
   if(sails.config.seeds.disable){
     callback()
   } else {
-    async.each(getModelsByPrioriy(), function(model, cb){
+    async.each(getModelsByPriority(), function(model, cb){
       if(sails.models[model].seed && sails.config.seeds[model] && !(sails.config.seeds[model].active === false)){
         sails.models[model].seed(cb);
       } else {


### PR DESCRIPTION
Hi, thanks for sails-seed. I applied a small patch to add a priority attribute to be able to seed collections in a specific order which is required when one collection depends on values of another such as a Profile collections that depends on a User collection.  

```
module.exports.seeds = {
    user: {
        priority: 1,
        data: [
            {
                id: 123,
                username: "testuser",
                password: "pass123"
            }
        ]
    },
    profile: {
        priority: 2,
        data: [
            {
                user: 123,
                firstname: "John",
                lastname: "Doe",
                country: "South Africa"
            }
        ]
    }
};
```
I tried to add a test but currently the tests are on a model level and I could not find a quick way to test priority ordering. 