### PR TITLE
Allow seeding order to be determined via a "priority" attribute

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,12 +47,19 @@ module.exports = function(sails){
   };
 };
 
+
+function getModelsByPriority(){
+  return _.sortBy(_.keys(sails.models), function(key){
+    return sails.models[key].priority;
+  });
+};
+
 function seeds(callback){
   if(sails.config.seeds.disable){
     callback()
   } else {
-    async.eachSeries(Object.keys(sails.models), function(model, cb){
-      if(sails.models[model].seed && !sails.config.seeds[model].active === false){
+    async.eachSeries(getModelsByPriority(), function(model, cb){
+      if(sails.models[model].seed && sails.config.seeds[model] && !(sails.config.seeds[model].active === false)){
         sails.models[model].seed(cb);
       } else {
         cb();
@@ -81,13 +88,15 @@ function patchAttributes(){
       var data = sails.config.seeds[model.identity];
       if(data){
         var extend = {};
-        if(_.some([data.overwrite, data.unique], _.isDefined)){
+        if(_.some([data.overwrite, data.unique, data.priority], _.isDefined)){
           extend.seedData = data.data ? data.data : [];
           extend.overwrite = data.overwrite;
-          extend.unique    = data.unique;
+          extend.unique = data.unique;
+          extend.priority = data.priority;
         } else {
           extend.seedData = data;
           extend.overwrite = false;
+          extend.priority = 0;
         }
 
         _.extend(model, extend);


### PR DESCRIPTION
Hi, thanks for sails-seed. I applied a small patch to add a priority attribute to be able to seed collections in a specific order which is required when one collection depends on values of another such as a Profile collections that depends on a User collection.

module.exports.seeds = {
    user: {
        priority: 1,
        data: [
            {
                id: 123,
                username: "testuser",
                password: "pass123"
            }
        ]
    },
    profile: {
        priority: 2,
        data: [
            {
                user: 123,
                firstname: "John",
                lastname: "Doe",
                country: "South Africa"
            }
        ]
    }
};
I tried to add a test but currently the tests are on a model level and I could not find a quick way to test priority ordering.